### PR TITLE
Resolve documentation drift across codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,11 +42,12 @@ Thank you for your interest in contributing to Quillmark Web! This document prov
 - **`src/lib/`** - The `@quillmark-test/web` library
   - `index.ts` - Main library exports
   - `loaders.ts` - Quill loading utilities (`fromZip`)
-  - `renderers.ts` - Rendering helpers
+  - `exporters.ts` - Rendering and export helpers
   - `utils.ts` - Utility functions
   - `types.ts` - TypeScript type definitions
 - **`public/quills/`** - Quill template zip files for testing
-- **`designs/`** - Design documents and specifications
+- **`prose/designs/`** - Design documents and specifications
+- **`prose/plans/`** - Implementation plans
 - **`index.html`** - Playground HTML template
 
 ## Code Style
@@ -103,7 +104,7 @@ When modifying the playground:
 
 If your changes affect the design:
 
-1. Update relevant files in `designs/`
+1. Update relevant files in `prose/designs/`
 2. Keep design docs in sync with implementation
 3. Document architectural decisions
 
@@ -177,7 +178,7 @@ Add fromZip validation for missing Quill.toml
 
 **Note:** Only maintainers with repository push access can create releases. Publishing to NPM is automated via GitHub Actions.
 
-The project uses an automated versioning workflow (see `designs/VERSIONING.MD`) that handles version bumping, git tagging, and pushing. A GitHub Action then detects the tag and publishes to NPM using credentials from the Publish environment.
+The project uses an automated versioning workflow that handles version bumping, git tagging, and pushing. A GitHub Action then detects the tag and publishes to NPM using credentials from the Publish environment.
 
 ### Release Commands
 
@@ -257,7 +258,7 @@ When contributing, keep these principles in mind:
 If you have questions about contributing:
 
 - Open a GitHub Issue with the "question" label
-- Review the design documents in `designs/`
+- Review the design documents in `prose/designs/` and `prose/plans/`
 - Check existing code for examples
 
 ## License

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ engine.registerQuill(quill);
 
 // Get SVG string to inject into your own widgets/components
 const result = exporters.render(engine, markdown);  // Defaults to SVG
-const svgString = new TextDecoder().decode(result.artifacts.main);
+const svgString = new TextDecoder().decode(result.artifacts as Uint8Array);
 
 // Use in your application
 myCustomWidget.innerHTML = svgString;
@@ -88,10 +88,12 @@ const result = exporters.render(engine, markdown, {
 **Returns:** `RenderResult` with standardized format
 ```typescript
 {
-  artifacts: { main: Uint8Array },
+  artifacts: Uint8Array | Uint8Array[] | Record<string, Uint8Array>,
   outputFormat: 'pdf' | 'svg'
 }
 ```
+
+For single-page documents, `artifacts` is a `Uint8Array`. For multi-page documents, it's `Uint8Array[]`. For documents with named artifacts, it's `Record<string, Uint8Array>`.
 
 ### Export Functions
 
@@ -99,7 +101,7 @@ All export functions accept `RenderResult` from `render()`:
 
 ```typescript
 // Get SVG string (primary use case - direct access)
-const svgString = new TextDecoder().decode(result.artifacts.main);
+const svgString = new TextDecoder().decode(result.artifacts as Uint8Array);
 myWidget.innerHTML = svgString;
 
 // Get Blob (for upload, storage, etc.)
@@ -199,7 +201,7 @@ Visit http://localhost:5173 for a live editor with template selection and real-t
 
 ## Version
 
-**v1.0.0** - Stable API with simplified architecture
+**v1.1.0** - Stable API with simplified architecture
 
 ## License
 

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -195,7 +195,7 @@ The zip file must contain `Quill.toml` at the root level.
 
 ## Testing
 
-This library follows the validated testing patterns from `quillmark-wasm` end-to-end tests. See [TESTING_DIFFERENCES.md](/docs/TESTING_DIFFERENCES.md) for a detailed comparison of testing approaches.
+This library follows the validated testing patterns from `quillmark-wasm` end-to-end tests.
 
 ### Test Structure
 


### PR DESCRIPTION
This commit resolves all documentation inconsistencies with the current implementation:

- Update version from v1.0.0 to v1.1.0 in README.md
- Fix RenderResult artifact access patterns in README.md
  - Changed from `result.artifacts.main` to `result.artifacts`
  - Added proper type documentation for artifacts union type
- Fix CONTRIBUTING.md file references
  - Changed `renderers.ts` to `exporters.ts`
  - Updated `designs/` references to `prose/designs/`
  - Added `prose/plans/` directory reference
  - Removed reference to non-existent VERSIONING.MD
- Remove broken link to non-existent TESTING_DIFFERENCES.md in src/lib/README.md

All tests pass and library builds successfully.